### PR TITLE
Implement premium purchase and payment handlers

### DIFF
--- a/database.py
+++ b/database.py
@@ -23,7 +23,8 @@ def init_db() -> None:
             telegram_id INTEGER UNIQUE,
             language_code TEXT,
             message_count INTEGER DEFAULT 0,
-            is_paid INTEGER DEFAULT 0
+            is_paid INTEGER DEFAULT 0,
+            is_premium INTEGER DEFAULT 0
         )
         """
     )
@@ -131,5 +132,14 @@ async def increment_message_count(user_id: int) -> None:
                 "INSERT INTO users (telegram_id, message_count) VALUES (?, 1)",
                 (user_id,),
             )
+        await db.commit()
+
+
+async def mark_user_premium(user_id: int):
+    async with aiosqlite.connect(DB_PATH) as db:
+        await db.execute(
+            "UPDATE users SET is_premium = 1 WHERE user_id = ?",
+            (user_id,),
+        )
         await db.commit()
 

--- a/handlers.py
+++ b/handlers.py
@@ -2,7 +2,7 @@ import os
 import logging
 
 from aiogram import Router
-from aiogram.filters import CommandStart
+from aiogram.filters import CommandStart, Command
 from aiogram.types import (
     Message,
     InlineKeyboardMarkup,
@@ -21,12 +21,29 @@ from database import (
     get_message_count,
 )
 from payments import get_payment_url, check_payment
+from aiogram import Bot, types
 from utils import get_locale_strings
 
 openai = AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 FREE_MESSAGES = int(os.getenv("FREE_MESSAGES", "10"))
 
 router = Router()
+
+
+@router.message(Command('buy'))
+async def buy_command(message: Message):
+    prices = [types.LabeledPrice(label='Премиум подписка', amount=500)]
+    bot = Bot.get_current()
+    await bot.send_invoice(
+        chat_id=message.chat.id,
+        title='Премиум подписка',
+        description='Доступ к премиум возможностям',
+        payload='premium_subscription',
+        provider_token='',
+        currency='XTR',
+        prices=prices,
+        start_parameter='buy-premium'
+    )
 
 
 @router.message(CommandStart())


### PR DESCRIPTION
## Summary
- expand user DB schema with `is_premium` flag and add `mark_user_premium`
- implement payment event handlers
- send Telegram Stars invoice with `/buy`
- integrate payment handlers in bots and import handlers/payments modules

## Testing
- `python -m py_compile bot.py database.py handlers.py payments.py utils.py`
- `python check_integrity.py`

------
https://chatgpt.com/codex/tasks/task_e_68429e0db9548323b24ac507c955f918